### PR TITLE
Create bean models

### DIFF
--- a/.sequelizerc
+++ b/.sequelizerc
@@ -3,7 +3,7 @@ const path = require('path');
 module.exports = {
   'config': path.resolve('api', 'config', 'config.js'),
   'models-path': path.resolve('api', 'models'),
-  'migrations-path': path.resolve('api', 'migrations')
+  'migrations-path': path.resolve('api', 'migrations'),
 }
 
 

--- a/api/migrations/20210513022753-create-user.js
+++ b/api/migrations/20210513022753-create-user.js
@@ -7,20 +7,6 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.STRING,
       },
-      devBeans: {
-        type: Sequelize.INTEGER,
-      },
-      goldenBeans: {
-        type: Sequelize.INTEGER,
-      },
-      createdAt: {
-        allowNull: false,
-        type: Sequelize.DATE,
-      },
-      updatedAt: {
-        allowNull: false,
-        type: Sequelize.DATE,
-      },
     });
   },
   down: async (queryInterface, Sequelize) => {

--- a/api/migrations/20210525230251-create-user.js
+++ b/api/migrations/20210525230251-create-user.js
@@ -7,6 +7,12 @@ module.exports = {
         primaryKey: true,
         type: Sequelize.STRING,
       },
+      devBeans: {
+        type: Sequelize.INTEGER,
+      },
+      goldenBeans: {
+        type: Sequelize.INTEGER,
+      },
       createdAt: {
         allowNull: false,
         type: Sequelize.DATE,

--- a/api/migrations/20210812174148-create-guild.js
+++ b/api/migrations/20210812174148-create-guild.js
@@ -3,6 +3,7 @@ module.exports = {
   up: async (queryInterface, Sequelize) => {
     await queryInterface.createTable("guilds", {
       id: {
+        primaryKey: true,
         allowNull: false,
         type: Sequelize.STRING,
       },

--- a/api/migrations/20210813200559-create-bean-type.js
+++ b/api/migrations/20210813200559-create-bean-type.js
@@ -1,0 +1,28 @@
+"use strict";
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("beanTypes", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal("uuid_generate_v4()"),
+      },
+      name: {
+        allowNull: false,
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("beanTypes");
+  },
+};

--- a/api/migrations/20210815220241-add-bean-types.js
+++ b/api/migrations/20210815220241-add-bean-types.js
@@ -1,0 +1,26 @@
+"use strict";
+console.log("add bean types");
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkInsert(
+      "beanTypes",
+      [
+        {
+          name: "DevBean",
+          createdAt: Sequelize.fn("NOW"),
+          updatedAt: Sequelize.fn("NOW"),
+        },
+        {
+          name: "GoldenBean",
+          createdAt: Sequelize.fn("NOW"),
+          updatedAt: Sequelize.fn("NOW"),
+        },
+      ],
+      {}
+    );
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete("beanTypes", null, {});
+  },
+};

--- a/api/migrations/20210816203116-create-bean-log.js
+++ b/api/migrations/20210816203116-create-bean-log.js
@@ -1,0 +1,50 @@
+"use strict";
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.createTable("BeanLogs", {
+      id: {
+        allowNull: false,
+        primaryKey: true,
+        type: Sequelize.UUID,
+        defaultValue: Sequelize.literal("uuid_generate_v4()"),
+      },
+      beanTypeId: {
+        type: Sequelize.UUID,
+        references: {
+          model: "beanTypes",
+          key: "id",
+        },
+      },
+      userId: {
+        type: Sequelize.STRING,
+        references: {
+          model: "users",
+          key: "id",
+        },
+      },
+      givenBy: {
+        type: Sequelize.STRING,
+      },
+      createdAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+      updatedAt: {
+        allowNull: false,
+        type: Sequelize.DATE,
+      },
+    });
+  },
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.dropTable("BeanLogs");
+  },
+};
+
+/*
+
+
+A beantype has many BeanLogs
+
+
+
+*/

--- a/api/migrations/20210823001355-remove-beans.js
+++ b/api/migrations/20210823001355-remove-beans.js
@@ -1,0 +1,19 @@
+"use strict";
+module.exports = {
+  up: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.removeColumn("users", "devBeans"),
+      queryInterface.removeColumn("users", "goldenBeans"),
+    ]);
+  },
+  down: (queryInterface, Sequelize) => {
+    return Promise.all([
+      queryInterface.addColumn("users", "devBeans", {
+        type: Sequelize.INTEGER,
+      }),
+      queryInterface.addColumn("users", "goldenBeans", {
+        type: Sequelize.INTEGER,
+      }),
+    ]);
+  },
+};

--- a/api/models/beanlog.js
+++ b/api/models/beanlog.js
@@ -1,0 +1,27 @@
+"use strict";
+const { Model } = require("sequelize");
+
+module.exports = (sequelize, DataTypes) => {
+  class BeanLog extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      // define association here
+    }
+  }
+  BeanLog.init(
+    {
+      beanType: DataTypes.UUID,
+      userId: DataTypes.STRING,
+      givenBy: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: "BeanLog",
+    }
+  );
+  return BeanLog;
+};

--- a/api/models/beantype.js
+++ b/api/models/beantype.js
@@ -1,0 +1,26 @@
+"use strict";
+const { Model } = require("sequelize");
+module.exports = (sequelize, DataTypes) => {
+  class BeanType extends Model {
+    /**
+     * Helper method for defining associations.
+     * This method is not a part of Sequelize lifecycle.
+     * The `models/index` file will call this method automatically.
+     */
+    static associate(models) {
+      BeanType.hasMany(models.BeanLog, {
+        foreignKey: "beanTypeId",
+      });
+    }
+  }
+  BeanType.init(
+    {
+      name: DataTypes.STRING,
+    },
+    {
+      sequelize,
+      modelName: "beanType",
+    }
+  );
+  return BeanType;
+};

--- a/api/models/index.js
+++ b/api/models/index.js
@@ -22,6 +22,8 @@ const db = {
   User: require("./user")(sequelize, Sequelize.DataTypes),
   Warning: require("./warning")(sequelize, Sequelize.DataTypes),
   Thread: require("./thread")(sequelize, Sequelize.DataTypes),
+  BeanType: require("./beantype")(sequelize, Sequelize.DataTypes),
+  BeanLog: require("./beanlog")(sequelize, Sequelize.DataTypes),
 };
 
 db.sequelize = sequelize;

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -7,6 +7,9 @@ module.exports = (sequelize, DataTypes) => {
       User.hasMany(models.Warning, {
         foreignKey: "userId",
       });
+      User.hasMany(models.BeanLog, {
+        foreignKey: "userId",
+      });
     }
   }
 


### PR DESCRIPTION
This PR adds two new models: BeanLog and BeanType.

Dev Beans and Golden Beans are now stored as a BeanType, with the attributes of an id, and a name. In the future, we might also store the image pertaining to the bean.

In the future, a BeanLog will be created every time a bean is given, containing some data about who received the bean, who gained the bean, when it was given etc. The BeanType will also be part of the BeanLog

To count the number of beans a user has, we can just sum up the number of BeanLogs they have associated with their User model.